### PR TITLE
adding pass trough flag for term_timeout of cloud_sql_proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,5 @@ Flags:
   --memory-limit="128Mi"  Memory limit of the sidecar container
   --proxy-version="1.11"  CloudSQL proxy version
   --verbose=VERBOSE       Verbose mode (eg. false)
+  --term-timeout          Delay CloudSQL proxy termination. Optional. Details: https://github.com/GoogleCloudPlatform/cloudsql-proxy 
 ```

--- a/main_test.go
+++ b/main_test.go
@@ -93,3 +93,262 @@ spec:
 	io.Copy(&buf, r)
 	assert.Equal(t, expectedOutput, buf.String())
 }
+
+func Test_runInjectorCorrectTimeout(t *testing.T) {
+
+	expectedOutput := `apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: test
+spec:
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+    spec:
+      containers:
+      - image: some-image
+        name: name-test
+        resources: {}
+      - command:
+        - /cloud_sql_proxy
+        - -instances=project-test:region-test:instance-test
+        - -log_debug_stdout=true
+        - -verbose=
+        - -credential_file=/secrets/cloudsql/credentials.json
+        - -term_timeout=35s
+        image: gcr.io/cloudsql-docker/gce-proxy:1.11
+        name: cloudsql-proxy
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 8Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 2
+        volumeMounts:
+        - mountPath: /secrets/cloudsql
+          name: cloudsql-proxy-credentials
+          readOnly: true
+      volumes:
+      - name: test-volume
+        secret:
+          secretName: test-secret
+      - name: cloudsql-proxy-credentials
+        secret:
+          secretName: cloudsql-proxy-credentials
+status: {}
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-svc
+spec:
+  ports:
+  - name: web
+    port: 8080`
+
+	// Just to trick to get control other stdout
+	// r and w are linked => whatever is written in w is readable in r
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	*path = "./test/test.yaml"
+	*instance = "instance-test"
+	*region = "region-test"
+	*project = "project-test"
+	*cpuRequest = "5m"
+	*memoryRequest = "8Mi"
+	*cpuLimit = "100m"
+	*memoryLimit = "128Mi"
+	*proxyVersion = "1.11"
+	*termTimeout = "35s"
+
+	runInjector()
+	os.Stdout = oldStdout
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	assert.Equal(t, expectedOutput, buf.String())
+}
+
+func Test_runInjectorTimeoutIncorrect(t *testing.T) {
+
+	expectedOutput := `apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: test
+spec:
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+    spec:
+      containers:
+      - image: some-image
+        name: name-test
+        resources: {}
+      - command:
+        - /cloud_sql_proxy
+        - -instances=project-test:region-test:instance-test
+        - -log_debug_stdout=true
+        - -verbose=
+        - -credential_file=/secrets/cloudsql/credentials.json
+        image: gcr.io/cloudsql-docker/gce-proxy:1.11
+        name: cloudsql-proxy
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 8Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 2
+        volumeMounts:
+        - mountPath: /secrets/cloudsql
+          name: cloudsql-proxy-credentials
+          readOnly: true
+      volumes:
+      - name: test-volume
+        secret:
+          secretName: test-secret
+      - name: cloudsql-proxy-credentials
+        secret:
+          secretName: cloudsql-proxy-credentials
+status: {}
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-svc
+spec:
+  ports:
+  - name: web
+    port: 8080`
+
+	// Just to trick to get control other stdout
+	// r and w are linked => whatever is written in w is readable in r
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	*path = "./test/test.yaml"
+	*instance = "instance-test"
+	*region = "region-test"
+	*project = "project-test"
+	*cpuRequest = "5m"
+	*memoryRequest = "8Mi"
+	*cpuLimit = "100m"
+	*memoryLimit = "128Mi"
+	*proxyVersion = "1.11"
+	*termTimeout = "35"
+
+	runInjector()
+	os.Stdout = oldStdout
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	assert.Equal(t, expectedOutput, buf.String())
+}
+
+func Test_runInjectorTimeoutEmpty(t *testing.T) {
+
+	expectedOutput := `apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: test
+spec:
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+    spec:
+      containers:
+      - image: some-image
+        name: name-test
+        resources: {}
+      - command:
+        - /cloud_sql_proxy
+        - -instances=project-test:region-test:instance-test
+        - -log_debug_stdout=true
+        - -verbose=
+        - -credential_file=/secrets/cloudsql/credentials.json
+        image: gcr.io/cloudsql-docker/gce-proxy:1.11
+        name: cloudsql-proxy
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 8Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 2
+        volumeMounts:
+        - mountPath: /secrets/cloudsql
+          name: cloudsql-proxy-credentials
+          readOnly: true
+      volumes:
+      - name: test-volume
+        secret:
+          secretName: test-secret
+      - name: cloudsql-proxy-credentials
+        secret:
+          secretName: cloudsql-proxy-credentials
+status: {}
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-svc
+spec:
+  ports:
+  - name: web
+    port: 8080`
+
+	// Just to trick to get control other stdout
+	// r and w are linked => whatever is written in w is readable in r
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	*path = "./test/test.yaml"
+	*instance = "instance-test"
+	*region = "region-test"
+	*project = "project-test"
+	*cpuRequest = "5m"
+	*memoryRequest = "8Mi"
+	*cpuLimit = "100m"
+	*memoryLimit = "128Mi"
+	*proxyVersion = "1.11"
+	*termTimeout = ""
+
+	runInjector()
+	os.Stdout = oldStdout
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	assert.Equal(t, expectedOutput, buf.String())
+}


### PR DESCRIPTION
While we are setting graceful shutdown in our services it does not have effect in case of multi container pods if we do not set graceful shutdown on supporting containers, too. 
In case of cloud_sql_proxy as the ambassador when pod is scheduled for termination it dies as soon it receives SIGTERM while main container waits for remaining requests to be processed. In this case waiting for queries from DB is useless(as they are dropped).

Cloud_sql_proxy have flag named `term_timeout` which if set waits for termination for given time period. If not then it is 0. 
This PR is using that fact and provides possibility to set term_timeout flag on injected cloud_sql_proxy so it will wait for main container and die at least at same time, if not after it.

Resources: 
- https://github.com/GoogleCloudPlatform/cloudsql-proxy
- https://cloud.google.com/blog/products/gcp/kubernetes-best-practices-terminating-with-grace